### PR TITLE
Fix weekly tasks on android version <= 34

### DIFF
--- a/app/src/main/java/com/xmission/trevin/android/todo/data/repeat/RepeatWeekly.java
+++ b/app/src/main/java/com/xmission/trevin/android/todo/data/repeat/RepeatWeekly.java
@@ -98,7 +98,7 @@ public class RepeatWeekly extends AbstractRepeat {
         // Get the next available day in the current week
         SortedSet<WeekDays> remainingDays =
                 new TreeSet<>(fixedWeekDays.tailSet(day));
-        remainingDays.removeFirst();
+        remainingDays.remove(remainingDays.first());
         if (remainingDays.isEmpty())
             // If no days left this week, skip `increment' weeks
             // and go to the first available day that week.


### PR DESCRIPTION
## Summary

Fixes a regression in weekly recurring tasks introduced in commit `eb3f3bf`. Checking off a task with a weekly recurrence schedule silently fails — the "done" state is not persisted and the task does not advance to its next due date. The checked state is lost on the next UI refresh.

## Root Cause

`RepeatWeekly.computeNextDueDate()` calls `remainingDays.removeFirst()` on a `TreeSet<WeekDays>` ([line 101](https://github.com/Typraeurion/Android-ToDo/blob/eb3f3bf511f84fb86dd0c8cf879659038766e425/app/src/main/java/com/xmission/trevin/android/todo/data/repeat/RepeatWeekly.java#L101)):

```java
SortedSet<WeekDays> remainingDays =
        new TreeSet<>(fixedWeekDays.tailSet(day));
remainingDays.removeFirst();  // ← problematic call
```

[`SortedSet.removeFirst()`](https://docs.oracle.com/en/java/javase/21/docs/api/java.base/java/util/SequencedCollection.html#removeFirst()) is a default method on the `SequencedCollection` interface, introduced in **Java 21** (JEP 431). Android's `TreeSet` does not implement this interface, so this call throws a `NoSuchMethodError` at runtime.

The intent of this line is to remove the current day of the week from the candidate set (since `tailSet()` is inclusive), so only future days within the same week remain. The logic is correct — only the API choice is wrong for the target platform.

## Fix

Replace the Java 21–only `removeFirst()` with equivalent `SortedSet`-compatible API that is available on all Android versions:

```java
remainingDays.remove(remainingDays.first());
```

This is semantically identical: `first()` returns the lowest element (guaranteed to be the current day, since `tailSet(day)` is inclusive of `day`), and `remove()` deletes it from the set.

## Impact

- **Weekly recurring tasks**: directly affected — checking off any weekly task would fail silently.
- **Other recurrence types** (daily, monthly, yearly, etc.): not affected — they do not use `removeFirst()`.
- **No behavioral change**: the fix preserves the exact same logic; only the method call is changed to one available on Android's API level.

## Testing

The existing `RepeatWeeklyTests` suite covers the `computeNextDueDate()` method across single-day, multi-day, and all-days-of-week configurations with various increments and end dates. These tests pass with the fix applied.